### PR TITLE
Fix: Android native connection errors are not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.7
+
+- Log all errors on the Android platform
+- Add mapping for native Android exceptions in methods: discover(), stopDiscovery(), connect(),
+  disconnect()
+- Fix getPeers() method: correct decoding from JSON
+- Update example: show empty peers state
+- Update example_full: show variant of checking running jobs
+
 ## 0.0.6
 
 - Update README: add a Feedback form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 0.0.7
 
 - Log all errors on the Android platform
-- Add mapping for native Android exceptions in methods: discover(), stopDiscovery(), connect(),
-  disconnect()
+- Add mapping for native Android exceptions in methods: discover(), stopDiscovery(), connect(), disconnect()
 - Fix getPeers() method: correct decoding from JSON
 - Update example: show empty peers state
 - Update example_full: show variant of checking running jobs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ Nearby Service Flutter Plugin is used to create connections in a P2P network.
 The plugin supports sending text messages and files. With it,
 you can easily create any kind of information sharing application **without Internet connection**.
 
-Your feedback and suggestions would be greatly appreciated! [You can leave your opinion here](https://forms.gle/FbAtW2dG5RYCxb1DA)
+The package does not support communication between Android and IOS devices, the connection is available for
+**Android-Android** and **IOS-IOS** relations.
+
+Your feedback and suggestions would be greatly
+appreciated! [You can leave your opinion here](https://forms.gle/FbAtW2dG5RYCxb1DA)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ appreciated! [You can leave your opinion here](https://forms.gle/FbAtW2dG5RYCxb1
 - [Data sharing](#data-sharing)
     - [Text messages](#text-messages)
     - [Resource messages](#resource-messages)
+- [Exceptions](#exceptions)
 - [Additional options](#additional-options)
 - [Demo](#demo)
 ## About
@@ -449,6 +450,32 @@ final filesListener = NearbyServiceFilesListener(
   },
 );
 ```
+
+## Exceptions
+
+**NearbyService** includes custom errors that you can catch in your implementation.
+
+**Common exceptions [See here](https://github.com/ksenia312/nearby_service/blob/main/lib/src/utils/exception.dart):**
+
+- `NearbyServiceUnsupportedPlatformException`: Usage of the plugin on an unsupported platform
+- `NearbyServiceUnsupportedDecodingException`: Error decoding messages from native platform to Dart (open an issue if
+  this happens)
+- `NearbyServiceInvalidMessageException`: An attempt to send an invalid message on the sender's side. Add content
+  validation to your messages
+
+**Exceptions that can be caught from the `discover()`, `stopDiscovery()`, `connect()`, and `disconnect()` methods for
+the Android platform
+[See here](https://github.com/ksenia312/nearby_service/blob/main/lib/src/platforms/android/utils/exception.dart):**
+
+- `NearbyServiceBusyException`: The Wi-Fi P2P framework is currently busy. Usually this means that you have sent a
+  request to some device and now one of the peers is **CONNECTING**
+- `NearbyServiceP2PPUnsupportedException`: Wi-Fi P2P is not supported on this device
+- `NearbyServiceNoServiceRequestsException`: No service discovery requests have been made. Ensure that you have
+  initiated a service discovery request before attempting to connect
+- `NearbyServiceGenericErrorException`: A generic error occurred. This could be due to various reasons such as hardware
+  issues, Wi-Fi being turned off, or temporary issues with the Wi-Fi P2P framework
+- `NearbyServiceUnknownException`: An unknown error occurred. Please check the device's Wi-Fi P2P settings and ensure
+  the device supports Wi-Fi P2P
 
 ## Additional options
 

--- a/android/src/main/kotlin/com/xenikii/nearby_service/Logger.kt
+++ b/android/src/main/kotlin/com/xenikii/nearby_service/Logger.kt
@@ -19,19 +19,19 @@ class Logger {
         var level = LogLevel.DEBUG
         fun d(message: String) {
             if (level.value <= LogLevel.DEBUG.value) {
-                Log.d(TAG, message)
+                Log.d(TAG, "\u001B[37m$message\u001B[0m")
             }
         }
 
         fun i(message: String) {
             if (level.value <= LogLevel.INFO.value) {
-                Log.i(TAG, message)
+                Log.i(TAG, "\u001B[32m$message\u001B[0m")
             }
         }
 
         fun e(message: String) {
             if (level.value <= LogLevel.ERROR.value) {
-                Log.e(TAG, message)
+                Log.e(TAG, "\u001B[31m$message\u001B[0m")
             }
         }
     }

--- a/android/src/main/kotlin/com/xenikii/nearby_service/NearbyServiceBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/xenikii/nearby_service/NearbyServiceBroadcastReceiver.kt
@@ -51,6 +51,11 @@ class NearbyServiceBroadcastReceiver(
         }
     }
 
+    fun init() {
+        writeDevices()
+        writeConnectionInfo()
+    }
+
     private fun logState(intent: Intent) {
         when (intent.getIntExtra(WifiP2pManager.EXTRA_WIFI_STATE, -1)) {
             WifiP2pManager.WIFI_P2P_STATE_ENABLED -> {

--- a/android/src/main/kotlin/com/xenikii/nearby_service/NearbyServiceManager.kt
+++ b/android/src/main/kotlin/com/xenikii/nearby_service/NearbyServiceManager.kt
@@ -248,7 +248,7 @@ class NearbyServiceManager(private var context: Context) {
                 val reason = when (reasonCode) {
                     WifiP2pManager.P2P_UNSUPPORTED -> "Wi-Fi P2P is not supported on this device. Please ensure your device supports Wi-Fi P2P."
                     WifiP2pManager.ERROR -> "A generic error occurred. This could be due to various reasons such as hardware issues, Wi-Fi being turned off, or temporary issues with the Wi-Fi P2P framework."
-                    WifiP2pManager.BUSY -> "The Wi-Fi P2P framework is currently busy. Please wait for the current operation to complete before initiating another."
+                    WifiP2pManager.BUSY -> "The Wi-Fi P2P framework is currently busy. Please wait for the current operation to complete before initiating another. Usually this means that you have sent a request to some device and now one of the peers is CONNECTING."
                     WifiP2pManager.NO_SERVICE_REQUESTS -> "No service discovery requests have been made. Ensure that you have initiated a service discovery request before attempting to connect."
                     else -> "An unknown error occurred. Please check the device's Wi-Fi P2P settings and ensure the device supports Wi-Fi P2P."
                 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -112,6 +112,7 @@ class _AppBodyState extends State<AppBody> {
         children: [
           if (Platform.isIOS)
             Text('You are ${_isIosBrowser ? 'Browser' : 'Advertiser'}'),
+          if (_peers.isEmpty) const Text('Searching for peers...'),
           ..._peers.map(
             (e) => PeerWidget(
               device: e,

--- a/example_full/lib/domain/app_service.dart
+++ b/example_full/lib/domain/app_service.dart
@@ -47,13 +47,12 @@ class AppService extends ChangeNotifier {
       await _nearbyService.initialize(
         data: NearbyInitializeData(iosDeviceName: iosDeviceName),
       );
+      await getCurrentDeviceInfo();
       updateState(
         Platform.isAndroid ? AppState.permissions : AppState.selectClientType,
       );
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } catch (e, s) {
+      _log(e, s);
     } finally {
       notifyListeners();
     }
@@ -62,10 +61,8 @@ class AppService extends ChangeNotifier {
   Future<void> getCurrentDeviceInfo() async {
     try {
       currentDeviceInfo = await _nearbyService.getCurrentDeviceInfo();
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } catch (e, s) {
+      _log(e, s);
     }
   }
 
@@ -75,10 +72,8 @@ class AppService extends ChangeNotifier {
       if (result ?? false) {
         updateState(AppState.checkServices);
       }
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } catch (e, s) {
+      _log(e, s);
     }
   }
 
@@ -101,17 +96,39 @@ class AppService extends ChangeNotifier {
     updateState(AppState.readyToDiscover);
   }
 
+  Future<bool> hasRunningJobs() async {
+    try {
+      final result = await _nearbyService.getPeers();
+      if (result.any(
+        (element) => element.status == NearbyDeviceStatus.connecting,
+      )) {
+        if (kDebugMode) {
+          print('Service has already running jobs');
+        }
+        return true;
+      }
+      return false;
+    } catch (e, s) {
+      _log(e, s);
+      return false;
+    }
+  }
+
   Future<void> discover() async {
     try {
-      await getCurrentDeviceInfo();
-      final result = await _nearbyService.discover();
-      if (result) {
+      final hasRunning = await hasRunningJobs();
+      if (hasRunning) {
         updateState(AppState.discoveringPeers);
+      } else {
+        final result = await _nearbyService.discover();
+        if (result) {
+          updateState(AppState.discoveringPeers);
+        }
       }
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } on NearbyServiceBusyException catch (_) {
+      _logBusyException();
+    } catch (e, s) {
+      _log(e, s);
     }
   }
 
@@ -121,20 +138,20 @@ class AppService extends ChangeNotifier {
       if (result) {
         updateState(AppState.readyToDiscover);
       }
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } on NearbyServiceBusyException catch (_) {
+      _logBusyException();
+    } catch (e, s) {
+      _log(e, s);
     }
   }
 
   Future<void> connect(NearbyDevice device) async {
     try {
       await _nearbyService.connect(device);
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } on NearbyServiceBusyException catch (_) {
+      _logBusyException();
+    } catch (e, s) {
+      _log(e, s);
     }
     notifyListeners();
   }
@@ -142,10 +159,10 @@ class AppService extends ChangeNotifier {
   Future<void> disconnect([NearbyDevice? device]) async {
     try {
       await _nearbyService.disconnect(device);
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } on NearbyServiceBusyException catch (_) {
+      _logBusyException();
+    } catch (e, s) {
+      _log(e, s);
     } finally {
       await stopListeningAll();
     }
@@ -194,10 +211,8 @@ extension ConnectionInfoExtension on AppService {
           _notify();
         },
       );
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } catch (e, s) {
+      _log(e, s);
     }
     _notify();
   }
@@ -218,10 +233,8 @@ extension PeersExtension on AppService {
         },
       );
       updateState(AppState.streamingPeers);
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } catch (e, s) {
+      _log(e, s);
     }
   }
 
@@ -310,10 +323,8 @@ extension CommunicationChannelExtension on AppService {
   Future<void> endCommunicationChannel() async {
     try {
       await _nearbyService.endCommunicationChannel();
-    } catch (e) {
-      if (kDebugMode) {
-        print(e);
-      }
+    } catch (e, s) {
+      _log(e, s);
     }
     _notify();
   }
@@ -382,5 +393,21 @@ extension MessagingExtension on AppService {
   void endFilesLoading(ReceivedNearbyFilesPack pack) {
     filesLoadings.remove(pack.id);
     _notify();
+  }
+}
+
+extension LoggingExtension on AppService {
+  void _log(e, StackTrace s) {
+    if (kDebugMode) {
+      print('$e, \nStacktrace: $s');
+    }
+  }
+
+  void _logBusyException() {
+    if (kDebugMode) {
+      print(
+        'Nearby service is busy, wait a little and retry (You can implement retry in your code)',
+      );
+    }
   }
 }

--- a/example_full/lib/domain/app_service.dart
+++ b/example_full/lib/domain/app_service.dart
@@ -47,7 +47,6 @@ class AppService extends ChangeNotifier {
       await _nearbyService.initialize(
         data: NearbyInitializeData(iosDeviceName: iosDeviceName),
       );
-      await getCurrentDeviceInfo();
       updateState(
         Platform.isAndroid ? AppState.permissions : AppState.selectClientType,
       );
@@ -117,6 +116,7 @@ class AppService extends ChangeNotifier {
 
   Future<void> discover() async {
     try {
+      await getCurrentDeviceInfo();
       final hasRunning = await hasRunningJobs();
       if (hasRunning) {
         updateState(AppState.discoveringPeers);

--- a/example_full/lib/domain/app_service.dart
+++ b/example_full/lib/domain/app_service.dart
@@ -99,6 +99,7 @@ class AppService extends ChangeNotifier {
   Future<bool> hasRunningJobs() async {
     try {
       final result = await _nearbyService.getPeers();
+      // if one of devices is connecting, service is busy (android only)
       if (result.any(
         (element) => element.status == NearbyDeviceStatus.connecting,
       )) {

--- a/lib/nearby_service.dart
+++ b/lib/nearby_service.dart
@@ -168,6 +168,13 @@ abstract class NearbyService {
   /// Note that the [NearbyIOSService] implementation starts **browsing** or
   /// **advertising** depending on the [NearbyIOSService.isBrowser].
   ///
+  /// On Android can throw mapped from native platform exceptions:
+  /// 1. [NearbyServiceBusyException]
+  /// 2. [NearbyServiceP2PUnsupportedException]
+  /// 3. [NearbyServiceNoServiceRequestsException]
+  /// 4. [NearbyServiceGenericErrorException]
+  /// 5. [NearbyServiceUnknownException]
+  ///
   Future<bool> discover();
 
   ///
@@ -175,6 +182,13 @@ abstract class NearbyService {
   ///
   /// Note that the [NearbyIOSService] implementation stops **browsing** or
   /// **advertising** depending on the [NearbyIOSService.isBrowser].
+  ///
+  /// On Android can throw mapped from native platform exceptions:
+  /// 1. [NearbyServiceBusyException]
+  /// 2. [NearbyServiceP2PUnsupportedException]
+  /// 3. [NearbyServiceNoServiceRequestsException]
+  /// 4. [NearbyServiceGenericErrorException]
+  /// 5. [NearbyServiceUnknownException]
   ///
   Future<bool> stopDiscovery();
 
@@ -187,6 +201,13 @@ abstract class NearbyService {
   /// Note that if [Platform.isIOS] == true, [NearbyIOSDevice] should be passed.
   /// If [Platform.isAndroid] == true, [NearbyAndroidDevice] should be passed.
   ///
+  /// On Android can throw mapped from native platform exceptions:
+  /// 1. [NearbyServiceBusyException]
+  /// 2. [NearbyServiceP2PUnsupportedException]
+  /// 3. [NearbyServiceNoServiceRequestsException]
+  /// 4. [NearbyServiceGenericErrorException]
+  /// 5. [NearbyServiceUnknownException]
+  ///
   Future<bool> connect(NearbyDevice device);
 
   ///
@@ -196,6 +217,14 @@ abstract class NearbyService {
   /// If [Platform.isAndroid] == true, [NearbyAndroidDevice] should be passed.
   ///
   /// **For IOS [device] is required!!!**
+  ///
+  /// On Android can throw mapped from native platform exceptions:
+  /// 1. [NearbyServiceBusyException]
+  /// 2. [NearbyServiceP2PUnsupportedException]
+  /// 3. [NearbyServiceNoServiceRequestsException]
+  /// 4. [NearbyServiceGenericErrorException]
+  /// 5. [NearbyServiceUnknownException]
+  ///
   Future<bool> disconnect([NearbyDevice? device]);
 
   ///

--- a/lib/nearby_service_method_channel.dart
+++ b/lib/nearby_service_method_channel.dart
@@ -37,7 +37,7 @@ class MethodChannelNearbyService extends NearbyServicePlatform {
   @override
   Future<List<NearbyDevice>> getPeers() async {
     return NearbyDeviceMapper.instance.mapToDeviceList(
-      await methodChannel.invokeMethod('fetchPeers'),
+      await methodChannel.invokeMethod('getPeers'),
     );
   }
 

--- a/lib/src/model/nearby_message_content.dart
+++ b/lib/src/model/nearby_message_content.dart
@@ -6,7 +6,7 @@ import 'package:nearby_service/nearby_service.dart';
 /// Contains [value] - the message to be sent or received.
 ///
 final class NearbyMessageTextRequest extends NearbyMessageContent {
-  const NearbyMessageTextRequest._({
+  const NearbyMessageTextRequest.createManually({
     required this.value,
     required super.id,
   });
@@ -17,7 +17,7 @@ final class NearbyMessageTextRequest extends NearbyMessageContent {
   /// Gets [NearbyMessageTextRequest] from [json]
   ///
   factory NearbyMessageTextRequest.fromJson(Map<String, dynamic>? json) {
-    return NearbyMessageTextRequest._(
+    return NearbyMessageTextRequest.createManually(
       id: json?['id'],
       value: json?['value'],
     );
@@ -76,7 +76,7 @@ final class NearbyMessageFilesRequest extends NearbyMessageContent {
   ///
   /// Adds a [NearbyFileInfo] list to [id] to identify files.
   ///
-  const NearbyMessageFilesRequest._({
+  const NearbyMessageFilesRequest.createManually({
     required super.id,
     required this.files,
   });
@@ -91,7 +91,7 @@ final class NearbyMessageFilesRequest extends NearbyMessageContent {
   /// Gets [NearbyMessageFilesRequest] from [json].
   ///
   factory NearbyMessageFilesRequest.fromJson(Map<String, dynamic>? json) {
-    return NearbyMessageFilesRequest._(
+    return NearbyMessageFilesRequest.createManually(
       id: json?['id'],
       files: [
         ...?(json?['files'] as List?)?.map(

--- a/lib/src/platforms/android/android.dart
+++ b/lib/src/platforms/android/android.dart
@@ -2,3 +2,4 @@ export 'nearby_android_service.dart';
 export 'nearby_service_android_interface.dart';
 export 'model/nearby_connection_info.dart';
 export 'model/nearby_device.dart';
+export 'utils/exception.dart';

--- a/lib/src/platforms/android/model/nearby_device.dart
+++ b/lib/src/platforms/android/model/nearby_device.dart
@@ -143,7 +143,7 @@ class NearbyAndroidMapper implements NearbyDeviceMapper {
     final decoded = JSONDecoder.decodeList(value);
     return [
       ...?decoded?.map(
-        (e) => NearbyAndroidDevice.fromJson(e as Map<String, dynamic>?),
+        (e) => NearbyAndroidDevice.fromJson(JSONDecoder.decodeMap(e)),
       ),
     ];
   }

--- a/lib/src/platforms/android/utils/exception.dart
+++ b/lib/src/platforms/android/utils/exception.dart
@@ -1,0 +1,63 @@
+import 'package:nearby_service/nearby_service.dart';
+
+const _kNearbyServiceMessage = 'Got error from native platform with status=';
+
+class NearbyServiceP2PUnsupportedException extends NearbyServiceException {
+  NearbyServiceP2PUnsupportedException()
+      : super(
+          '${_kNearbyServiceMessage}P2P_UNSUPPORTED',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceP2PUnsupportedException{error: $error}';
+  }
+}
+
+class NearbyServiceBusyException extends NearbyServiceException {
+  NearbyServiceBusyException()
+      : super(
+          '${_kNearbyServiceMessage}BUSY',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceBusyException{error: $error}';
+  }
+}
+
+class NearbyServiceNoServiceRequestsException extends NearbyServiceException {
+  NearbyServiceNoServiceRequestsException()
+      : super(
+          '${_kNearbyServiceMessage}NO_SERVICE_REQUESTS',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceNoServiceRequestsException{error: $error}';
+  }
+}
+
+class NearbyServiceWifiException extends NearbyServiceException {
+  NearbyServiceWifiException()
+      : super(
+          '${_kNearbyServiceMessage}ERROR',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceWifiException{error: $error}';
+  }
+}
+
+class NearbyServiceUnknownException extends NearbyServiceException {
+  NearbyServiceUnknownException()
+      : super(
+          '${_kNearbyServiceMessage}UNKNOWN',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceUnknownException{error: $error}';
+  }
+}

--- a/lib/src/platforms/android/utils/exception.dart
+++ b/lib/src/platforms/android/utils/exception.dart
@@ -2,6 +2,9 @@ import 'package:nearby_service/nearby_service.dart';
 
 const _kNearbyServiceMessage = 'Got error from native platform with status=';
 
+///
+/// Wi-Fi P2P is not supported on this device
+///
 class NearbyServiceP2PUnsupportedException extends NearbyServiceException {
   NearbyServiceP2PUnsupportedException()
       : super(
@@ -14,6 +17,13 @@ class NearbyServiceP2PUnsupportedException extends NearbyServiceException {
   }
 }
 
+///
+/// The Wi-Fi P2P framework is currently busy.
+/// Please wait for the current operation to complete before initiating another.
+///
+/// Usually this means that you have sent a request to some device and
+/// now one of the peers is CONNECTING.
+///
 class NearbyServiceBusyException extends NearbyServiceException {
   NearbyServiceBusyException()
       : super(
@@ -26,6 +36,10 @@ class NearbyServiceBusyException extends NearbyServiceException {
   }
 }
 
+///
+/// No service discovery requests have been made. Ensure that you have
+/// initiated a service discovery request before attempting to connect.
+///
 class NearbyServiceNoServiceRequestsException extends NearbyServiceException {
   NearbyServiceNoServiceRequestsException()
       : super(
@@ -38,18 +52,27 @@ class NearbyServiceNoServiceRequestsException extends NearbyServiceException {
   }
 }
 
-class NearbyServiceWifiException extends NearbyServiceException {
-  NearbyServiceWifiException()
+///
+/// A generic error occurred. This could be due to various reasons such as
+/// hardware issues, Wi-Fi being turned off, or temporary issues with the
+/// Wi-Fi P2P framework.
+///
+class NearbyServiceGenericErrorException extends NearbyServiceException {
+  NearbyServiceGenericErrorException()
       : super(
           '${_kNearbyServiceMessage}ERROR',
         );
 
   @override
   String toString() {
-    return 'NearbyServiceWifiException{error: $error}';
+    return 'NearbyServiceGenericErrorException{error: $error}';
   }
 }
 
+///
+/// An unknown error occurred. Please check the device's Wi-Fi
+/// P2P settings and ensure the device supports Wi-Fi P2P.
+///
 class NearbyServiceUnknownException extends NearbyServiceException {
   NearbyServiceUnknownException()
       : super(

--- a/lib/src/platforms/android/utils/mapper.dart
+++ b/lib/src/platforms/android/utils/mapper.dart
@@ -12,7 +12,7 @@ class NearbyServiceAndroidExceptionMapper {
     } catch (_) {}
     return switch (enumValue) {
       AndroidFailureCodes.BUSY => NearbyServiceBusyException(),
-      AndroidFailureCodes.ERROR => NearbyServiceWifiException(),
+      AndroidFailureCodes.ERROR => NearbyServiceGenericErrorException(),
       AndroidFailureCodes.P2P_UNSUPPORTED =>
         NearbyServiceP2PUnsupportedException(),
       AndroidFailureCodes.NO_SERVICE_REQUESTS =>

--- a/lib/src/platforms/android/utils/mapper.dart
+++ b/lib/src/platforms/android/utils/mapper.dart
@@ -1,0 +1,26 @@
+import 'package:nearby_service/nearby_service.dart';
+
+class NearbyServiceAndroidExceptionMapper {
+  NearbyServiceAndroidExceptionMapper._();
+
+  static NearbyServiceException map(String error) {
+    AndroidFailureCodes? enumValue;
+    try {
+      enumValue = AndroidFailureCodes.values.firstWhere(
+        (element) => element.name == error,
+      );
+    } catch (_) {}
+    return switch (enumValue) {
+      AndroidFailureCodes.BUSY => NearbyServiceBusyException(),
+      AndroidFailureCodes.ERROR => NearbyServiceWifiException(),
+      AndroidFailureCodes.P2P_UNSUPPORTED =>
+        NearbyServiceP2PUnsupportedException(),
+      AndroidFailureCodes.NO_SERVICE_REQUESTS =>
+        NearbyServiceNoServiceRequestsException(),
+      _ => NearbyServiceUnknownException(),
+    };
+  }
+}
+
+// ignore: constant_identifier_names
+enum AndroidFailureCodes { P2P_UNSUPPORTED, BUSY, NO_SERVICE_REQUESTS, ERROR }

--- a/lib/src/platforms/ios/model/nearby_device.dart
+++ b/lib/src/platforms/ios/model/nearby_device.dart
@@ -78,7 +78,7 @@ class NearbyIOSMapper implements NearbyDeviceMapper {
     final decoded = JSONDecoder.decodeList(value);
     return [
       ...?decoded?.map(
-        (e) => NearbyIOSDevice.fromJson(e as Map<String, dynamic>?),
+        (e) => NearbyIOSDevice.fromJson(JSONDecoder.decodeMap(e)),
       ),
     ];
   }

--- a/lib/src/utils/exception.dart
+++ b/lib/src/utils/exception.dart
@@ -16,31 +16,81 @@ class NearbyServiceException implements Exception {
   ///
   /// A call from an unsupported platform.
   ///
-  factory NearbyServiceException.unsupportedPlatform({required String caller}) {
-    return NearbyServiceException(
-      '$caller is not supported for platform ${Platform.operatingSystem}',
-    );
-  }
+  factory NearbyServiceException.unsupportedPlatform({
+    required String caller,
+  }) =>
+      NearbyServiceUnsupportedPlatformException(caller: caller);
 
   ///
   /// A decoding error.
   ///
-  factory NearbyServiceException.unsupportedDecoding(dynamic value) {
-    return NearbyServiceException(
-      'Got unknown value=$value with runtimeType=${value.runtimeType}',
-    );
-  }
+  factory NearbyServiceException.unsupportedDecoding(dynamic value) =>
+      NearbyServiceUnsupportedDecodingException(value);
 
-  factory NearbyServiceException.invalidMessage(NearbyMessageContent content) {
-    return NearbyServiceException(
-      'The message="$content" is not valid',
-    );
-  }
+  ///
+  /// Invalid message error
+  ///
+  factory NearbyServiceException.invalidMessage(NearbyMessageContent content) =>
+      NearbyServiceInvalidMessageException(content);
 
   final Object? error;
 
   @override
   String toString() {
     return 'NearbyServiceException{error: $error}';
+  }
+}
+
+///
+/// A call from an unsupported platform.
+///
+class NearbyServiceUnsupportedPlatformException extends NearbyServiceException {
+  ///
+  /// A call from an unsupported platform - default constructor
+  ///
+  NearbyServiceUnsupportedPlatformException({required String caller})
+      : super(
+          '$caller is not supported for platform ${Platform.operatingSystem}',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceUnsupportedPlatformException{error: $error}';
+  }
+}
+
+///
+/// A decoding error
+///
+class NearbyServiceUnsupportedDecodingException extends NearbyServiceException {
+  ///
+  /// A decoding error - default constructor
+  ///
+  NearbyServiceUnsupportedDecodingException(dynamic value)
+      : super(
+          'Got unknown value=$value with runtimeType=${value.runtimeType}',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceUnsupportedDecodingException{error: $error}';
+  }
+}
+
+///
+/// Invalid message error
+///
+class NearbyServiceInvalidMessageException extends NearbyServiceException {
+  ///
+  /// Invalid message error - default constructor
+  ///
+  NearbyServiceInvalidMessageException(NearbyMessageContent content)
+      : super(
+          'The message="$content" is not valid',
+        );
+
+  @override
+  String toString() {
+    return 'NearbyServiceInvalidMessageException{error: $error}';
   }
 }

--- a/lib/src/utils/exception.dart
+++ b/lib/src/utils/exception.dart
@@ -14,7 +14,7 @@ class NearbyServiceException implements Exception {
   }
 
   ///
-  /// A call from an unsupported platform.
+  /// Usage of the plugin on an unsupported platform
   ///
   factory NearbyServiceException.unsupportedPlatform({
     required String caller,
@@ -22,13 +22,15 @@ class NearbyServiceException implements Exception {
       NearbyServiceUnsupportedPlatformException(caller: caller);
 
   ///
-  /// A decoding error.
+  /// Error decoding messages from native platform to Dart (open an issue if
+  /// this happens!)
   ///
   factory NearbyServiceException.unsupportedDecoding(dynamic value) =>
       NearbyServiceUnsupportedDecodingException(value);
 
   ///
-  /// Invalid message error
+  /// An attempt to send an invalid message on the sender's side. Add content
+  /// validation to your messages
   ///
   factory NearbyServiceException.invalidMessage(NearbyMessageContent content) =>
       NearbyServiceInvalidMessageException(content);
@@ -42,11 +44,11 @@ class NearbyServiceException implements Exception {
 }
 
 ///
-/// A call from an unsupported platform.
+/// Usage of the plugin on an unsupported platform
 ///
 class NearbyServiceUnsupportedPlatformException extends NearbyServiceException {
   ///
-  /// A call from an unsupported platform - default constructor
+  /// Usage of the plugin on an unsupported platform - default constructor
   ///
   NearbyServiceUnsupportedPlatformException({required String caller})
       : super(
@@ -60,7 +62,8 @@ class NearbyServiceUnsupportedPlatformException extends NearbyServiceException {
 }
 
 ///
-/// A decoding error
+/// Error decoding messages from native platform to Dart (open an issue if
+/// this happens!)
 ///
 class NearbyServiceUnsupportedDecodingException extends NearbyServiceException {
   ///
@@ -78,7 +81,8 @@ class NearbyServiceUnsupportedDecodingException extends NearbyServiceException {
 }
 
 ///
-/// Invalid message error
+/// An attempt to send an invalid message on the sender's side. Add content
+/// validation to your messages
 ///
 class NearbyServiceInvalidMessageException extends NearbyServiceException {
   ///

--- a/lib/src/utils/file_socket.dart
+++ b/lib/src/utils/file_socket.dart
@@ -62,10 +62,10 @@ class FilesSocket {
       addChunk(event);
     } else if (event == separateCommandOf(_currentFileIndex)) {
       _futures.add(_createFile(_currentFileIndex));
+      Logger.info('Completed receiving file №${_currentFileIndex + 1}');
       _currentFileIndex = _currentFileIndex + 1;
       _chunksCount = 0;
       _bytesTable['$_currentFileIndex'] = [];
-      Logger.info('Completed receiving file №${_currentFileIndex - 1}');
     } else if (event == finishCommand) {
       await Future.wait(_futures);
       Logger.info('Files pack ${filesRequest.id} was created');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nearby_service
 description: Nearby Service Flutter Plugin is used to create connections in a P2P network. Supports sending text messages and files.
-version: 0.0.6
+version: 0.0.7
 homepage: https://github.com/ksenia312/nearby_service
 repository: https://github.com/ksenia312/nearby_service
 


### PR DESCRIPTION
## Fix for #4 

Now native errors will be logged!
New exceptions from Android have also been added: 
1. `NearbyServiceBusyException`
2. `NearbyServiceP2PUnsupportedException`
3. `NearbyServiceNoServiceRequestsException`
4. `NearbyServiceGenericErrorException`
5. `NearbyServiceUnknownException`

They can be caught from the methods `discover()`, `stopDiscovery()`, `connect()`, `disconnect()`

Also, the **example_full** in the `AppService` class now shows how to avoid the popular `NearbyServiceBusyException` error through checking the status of current peers - `hasRunningJobs()` method.

