### PR TITLE
[iOS, Android]: Use NearbyServiceListenable for stream controllers and their values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Fix issue https://github.com/ksenia312/nearby_service/issues/16
+
 ## 0.1.0
 
 **!! BREAKING CHANGES !!**

--- a/lib/src/platforms/android/nearby_android_service.dart
+++ b/lib/src/platforms/android/nearby_android_service.dart
@@ -170,7 +170,7 @@ class NearbyAndroidService extends NearbyService {
 
   @override
   Stream<CommunicationChannelState> getCommunicationChannelStateStream() {
-    return _socketService.stateController.stream.asBroadcastStream();
+    return _socketService.state.broadcastStream;
   }
 
   void _requireAndroidDevice(NearbyDevice device) {

--- a/lib/src/utils/listenable.dart
+++ b/lib/src/utils/listenable.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+class NearbyServiceListenable<T> {
+  NearbyServiceListenable({required this.initialValue});
+
+  final T initialValue;
+  late final ValueNotifier<T> notifier = ValueNotifier<T>(initialValue);
+  late final StreamController<T> _controller = StreamController<T>.broadcast()
+    ..add(notifier.value);
+
+  T get value => notifier.value;
+
+  Stream<T> get broadcastStream => _controller.stream.asBroadcastStream();
+
+  void add(T value) {
+    notifier.value = value;
+    _controller.add(value);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nearby_service
 description: Nearby Service Flutter Plugin is used to create connections in a P2P network. Supports sending text messages and files.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/ksenia312/nearby_service
 repository: https://github.com/ksenia312/nearby_service
 


### PR DESCRIPTION
### Description

`StreamController`s and `ValueNotifier`s (deprecated) previously were connected by:
```dart
  late final _controller = StreamController<bool>.broadcast()
    ..add(_notifier.value)
    ..stream.asBroadcastStream().listen((e) => _notifier.value = e);
```
This code produce problem that if we want synchronously update  `_notifier` and then use it, after `_controller.add()` it takes time to execute `listen()` and update `_notifier`

### Related Issue

If this pull request addresses an existing issue, please provide the issue number. If it is related
to an issue, mention it here

- Issue Number: #16 
